### PR TITLE
Fix missing ReactNode imports

### DIFF
--- a/src/modules/FunctionalSkillsPage.tsx
+++ b/src/modules/FunctionalSkillsPage.tsx
@@ -1,6 +1,8 @@
+import type { ReactNode } from 'react';
+
 interface FunctionalSkillsPageProps {
   level: string;
-  content?: React.ReactNode;
+  content?: ReactNode;
 }
 
 const FunctionalSkillsPage = ({ level, content }: FunctionalSkillsPageProps) => {

--- a/src/modules/VocabularyPage.tsx
+++ b/src/modules/VocabularyPage.tsx
@@ -1,6 +1,8 @@
+import type { ReactNode } from 'react';
+
 interface VocabularyPageProps {
   level: string;
-  content?: React.ReactNode;
+  content?: ReactNode;
 }
 
 const VocabularyPage = ({ level, content }: VocabularyPageProps) => {


### PR DESCRIPTION
## Summary
- import ReactNode type for vocabulary page
- import ReactNode type for functional skills page

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686735857c588324ab9a32a51497f09e