### PR TITLE
Add LevelPage not-found test

### DIFF
--- a/test/LevelPage.test.tsx
+++ b/test/LevelPage.test.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import LevelPage from "../src/pages/LevelPage";
+
+describe("LevelPage", () => {
+  it("renders not found message for invalid params", () => {
+    render(
+      <MemoryRouter initialEntries={["/invalid/wrong"]}>
+        <Routes>
+          <Route path="/:level/:category" element={<LevelPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Page not found/i)).toBeInTheDocument();
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -2,7 +2,7 @@ import { afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-afterEach(()=>{
-    cleanup();
-    vi.clearAllMocks()
-})
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});


### PR DESCRIPTION
## Summary
- add missing newline to `test/setup.ts`
- test LevelPage shows not-found message for invalid route params

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68686aa103048324b6a2d32923084882